### PR TITLE
feat: use more robust way to exit editor&expert interview

### DIFF
--- a/src/web_research_graph/interviews_graph/nodes/question.py
+++ b/src/web_research_graph/interviews_graph/nodes/question.py
@@ -2,9 +2,10 @@
 
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
+import json
 
 from web_research_graph.configuration import Configuration
-from web_research_graph.state import InterviewState
+from web_research_graph.state import InterviewState, EditorResponse
 from web_research_graph.prompts import INTERVIEW_QUESTION_PROMPT
 from web_research_graph.utils import load_chat_model
 from web_research_graph.utils import sanitize_name, swap_roles
@@ -21,17 +22,41 @@ async def generate_question(state: InterviewState, config: RunnableConfig):
     editor_name = sanitize_name(editor.name)
     swapped = swap_roles(state, editor_name)
     
-    chain = INTERVIEW_QUESTION_PROMPT | model
+    # Use structured output
+    chain = INTERVIEW_QUESTION_PROMPT | model.with_structured_output(EditorResponse)
     
-    result = await chain.ainvoke(
-        {"messages": swapped.messages, "persona": editor.persona},
-        config
-    )
-    
-    content = result.content if hasattr(result, 'content') else str(result)
+    try:
+        result = await chain.ainvoke(
+            {"messages": swapped.messages, "persona": editor.persona},
+            config
+        )
+        
+        # Extract message content and store end conversation intent in state
+        content = result.message
+        
+        # Add metadata to the message to indicate conversation end intent
+        message = AIMessage(
+            content=content, 
+            name=editor_name,
+            additional_kwargs={
+                "wants_to_end": result.wants_to_end,
+                "end_reason": result.reason
+            }
+        )
+        
+    except Exception as e:
+        # Fallback to regular text output if structured output fails
+        print(f"[WARNING] Structured output failed, falling back to text: {e}")
+        chain = INTERVIEW_QUESTION_PROMPT | model
+        result = await chain.ainvoke(
+            {"messages": swapped.messages, "persona": editor.persona},
+            config
+        )
+        content = result.content if hasattr(result, 'content') else str(result)
+        message = AIMessage(content=content, name=editor_name)
     
     return InterviewState(
-        messages=state.messages + [AIMessage(content=content, name=editor_name)],
+        messages=state.messages + [message],
         editor=state.editor,
         references=state.references,
         editors=state.editors,

--- a/src/web_research_graph/prompts.py
+++ b/src/web_research_graph/prompts.py
@@ -58,7 +58,16 @@ INTERVIEW_QUESTION_PROMPT = ChatPromptTemplate.from_messages(
 Besides your identity as a Wikipedia writer, you have a specific focus when researching the topic. \
 Now, you are chatting with an expert to get information. Ask good questions to get more useful information.
 
-When you have no more questions to ask, say "Thank you so much for your help!" to end the conversation.\
+You must respond with a structured JSON format containing:
+- "message": Your question or response content
+- "wants_to_end": true if you want to end the conversation, false otherwise
+- "reason": Optional reason for ending (only if wants_to_end is true)
+
+Set "wants_to_end" to true when:
+- You have gathered sufficient information for your perspective
+- You feel the expert has answered your key questions thoroughly
+- You want to express gratitude and conclude the interview
+
 Please only ask one question at a time and don't ask what you have asked before.\
 Your questions should be related to the topic you want to write.
 Be comprehensive and curious, gaining as much unique insight from the expert as possible.\

--- a/src/web_research_graph/state.py
+++ b/src/web_research_graph/state.py
@@ -130,6 +130,20 @@ class TopicValidation(BaseModel):
         description="Feedback message about the topic validation result"
     )
 
+class EditorResponse(BaseModel):
+    """Structured output for editor responses during interviews."""
+    
+    message: str = Field(
+        description="The editor's question or response content"
+    )
+    wants_to_end: bool = Field(
+        description="Whether the editor wants to end the conversation"
+    )
+    reason: Optional[str] = Field(
+        default=None,
+        description="Optional reason for ending the conversation"
+    )
+
 def default_topic_validation() -> TopicValidation:
     """Create a default TopicValidation instance."""
     return TopicValidation(is_valid=False, topic=None, message=None)


### PR DESCRIPTION
This pull request introduces structured output for editor responses during interviews, enhancing metadata handling and improving conversation flow management. Key changes include the addition of the `EditorResponse` model, updates to the prompt format, and modifications to message routing logic to incorporate structured metadata.

### Structured Output Enhancements:
* [`src/web_research_graph/state.py`](diffhunk://#diff-21cdfbfcb8b8b76b6b167efd26a7ce7cc45d3faff0028e14db047df8fdd8fe82R133-R146): Added the `EditorResponse` class to define structured output for editor responses, including fields for `message`, `wants_to_end`, and an optional `reason`.
* [`src/web_research_graph/prompts.py`](diffhunk://#diff-265a9dfaa3e2108b87f5e96f1a19678f71b0b1562c4db9712317b4e8c0637f03L61-R70): Updated the interview question prompt to require responses in a structured JSON format, specifying metadata like `wants_to_end` and `reason`.

### Conversation Flow Improvements:
* [`src/web_research_graph/interviews_graph/nodes/question.py`](diffhunk://#diff-9813d68bb8d1a3c40afdc4c96b49734d4344b849e0e81c20adf1b6b8d9dcf92cL24-R59): Modified the `generate_question` function to use structured output (`EditorResponse`) and fallback to regular text output if structured output fails. Added metadata handling for conversation end intent.
* [`src/web_research_graph/interviews_graph/router.py`](diffhunk://#diff-ef9db7bd9b0a03288db7d3907168608e7cd10dded3bec68658381d15e6edf256L43-R63): Updated `route_messages` to check for structured metadata (`wants_to_end` and `reason`) in editor responses, enabling better conversation termination logic.

### Codebase Updates:
* [`src/web_research_graph/interviews_graph/nodes/question.py`](diffhunk://#diff-9813d68bb8d1a3c40afdc4c96b49734d4344b849e0e81c20adf1b6b8d9dcf92cR5-R8): Added `json` import and updated imports to include `EditorResponse`.