### PR TITLE
feat: Add max_turns configuration for editor-expert conversations

### DIFF
--- a/mydemo.py
+++ b/mydemo.py
@@ -23,6 +23,7 @@ async def main():
         "fast_llm_model": "openai/gpt-4o-mini",
         "long_context_model": "openai/gpt-4o",
         "max_search_results": 3, # 你也可以覆盖非模型参数
+        "max_turns": 5, # 每个编辑与专家的最大对话轮数
         "system_prompt": "You are a helpful assistant that can help with research tasks." # 甚至可以覆盖系统提示
     }
 

--- a/src/web_research_graph/configuration.py
+++ b/src/web_research_graph/configuration.py
@@ -55,6 +55,13 @@ class Configuration:
         },
     )
 
+    max_turns: int = field(
+        default=3,
+        metadata={
+            "description": "The maximum number of turns (question-answer pairs) for each editor-expert conversation."
+        },
+    )
+
     @classmethod
     def from_runnable_config(
         cls, config: Optional[RunnableConfig] = None

--- a/src/web_research_graph/interviews_graph/router.py
+++ b/src/web_research_graph/interviews_graph/router.py
@@ -1,15 +1,20 @@
 """Router functions for managing interview flow."""
 
 from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableConfig
 
+from web_research_graph.configuration import Configuration
 from web_research_graph.state import InterviewState
 from web_research_graph.utils import sanitize_name
 
-MAX_TURNS = 3
 EXPERT_NAME = "expert"
 
-def route_messages(state: InterviewState) -> str:
+def route_messages(state: InterviewState, config: RunnableConfig = None) -> str:
     """Determine whether to continue the interview or end it."""
+    # Get configuration
+    configuration = Configuration.from_runnable_config(config)
+    max_turns = configuration.max_turns
+    
     if not state.messages:
         return "end"
         
@@ -31,6 +36,7 @@ def route_messages(state: InterviewState) -> str:
     # Debug: Print current conversation state
     print(f"[DEBUG] Current editor: {current_editor_name}")
     print(f"[DEBUG] Total messages in conversation: {len(current_messages)}")
+    print(f"[DEBUG] Max turns configured: {max_turns}")
     
     # Get the last message
     if current_messages:
@@ -62,8 +68,8 @@ def route_messages(state: InterviewState) -> str:
             print(f"[DEBUG] Expert responses so far: {expert_responses}")
             
             # Check if we've reached max turns
-            if expert_responses >= MAX_TURNS:
-                print("[DEBUG] Max turns reached - ending conversation")
+            if expert_responses >= max_turns:
+                print(f"[DEBUG] Max turns ({max_turns}) reached - ending conversation")
                 return "next_editor"
             
             print("[DEBUG] Continuing conversation - editor should ask next question")


### PR DESCRIPTION
This pull request introduces changes to make the maximum number of turns in editor-expert conversations configurable, replacing the hardcoded value with a dynamic configuration. The updates span multiple files, integrating the new `max_turns` parameter into the system. Below is a summary of the most important changes.

### Configuration Updates:
* [`src/web_research_graph/configuration.py`](diffhunk://#diff-b4793c589e4e57a6237c2e7b283fada7748ec7db5c3716e621f63d31b02be165R58-R64): Added a new `max_turns` field to the `Configuration` class, with a default value of 3 and metadata describing its purpose.

### Integration of Configurable `max_turns`:
* [`src/web_research_graph/interviews_graph/router.py`](diffhunk://#diff-ef9db7bd9b0a03288db7d3907168608e7cd10dded3bec68658381d15e6edf256R4-R17): Replaced the hardcoded `MAX_TURNS` constant with the `max_turns` value from the `Configuration` class, passed via a `RunnableConfig` parameter. Updated the `route_messages` function to use this configuration dynamically. [[1]](diffhunk://#diff-ef9db7bd9b0a03288db7d3907168608e7cd10dded3bec68658381d15e6edf256R4-R17) [[2]](diffhunk://#diff-ef9db7bd9b0a03288db7d3907168608e7cd10dded3bec68658381d15e6edf256L65-R72)
* [`src/web_research_graph/interviews_graph/router.py`](diffhunk://#diff-ef9db7bd9b0a03288db7d3907168608e7cd10dded3bec68658381d15e6edf256R39): Added debug logging to display the configured `max_turns` value during the interview flow for easier troubleshooting.

### Minor Adjustments:
* [`mydemo.py`](diffhunk://#diff-10ad0e0080ceb1fe76e4b41ade78ed5ee3eb5aff137b90d8be407ebc88b79601R26): Updated the example configuration to include the new `max_turns` parameter with a value of 5, showcasing its usage.